### PR TITLE
Enable python3 build

### DIFF
--- a/scripts/makeupdate
+++ b/scripts/makeupdate
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-import md5
+import hashlib
 import binascii
 
 if len(sys.argv) != 3:
@@ -13,11 +13,10 @@ outfile = sys.argv[2]
 
 print('makeupdate ' + infile + ' -> ' + outfile)
 
-data = open(infile, 'r').read()
-m = md5.new()
-m.update(data)
+data = open(infile, 'rb').read()
+m = hashlib.md5(data)
 md5sum = m.digest()
-open(outfile, 'w').write(data + md5sum)
+open(outfile, 'wb').write(data + md5sum)
 
 print('size: ' + str(len(data)) + ' bytes')
-print('md5sum: ' + binascii.hexlify(md5sum))
+print('md5sum: ' + binascii.hexlify(md5sum).decode('utf-8'))


### PR DESCRIPTION
Hi Simon,
I was able to build on windows using msys2 environment. Only thing to change was this python script to run with python 3.
Best,
Oliver