### PR TITLE
RingBuffer issue on pointer overflow applying modulo

### DIFF
--- a/src/core/utils/RingBuffer.h
+++ b/src/core/utils/RingBuffer.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
-template<typename T, size_t Size>
+template<typename T, int32_t Size>
 class RingBuffer {
 public:
     inline size_t size() const { return Size; }
@@ -11,14 +12,18 @@ public:
 
     inline bool full() const { return writable() == 0; }
 
-    inline size_t entries() const { return (_write - _read) % Size; }
+    inline size_t entries() const {
+        int32_t size = (_write - _read) % Size;
+        if(size < 0) size += Size;
+        return static_cast<size_t>(size);
+    }
 
     inline size_t writable() const {
-        return (_read - _write - 1) % Size;
+        return Size - readable();
     }
 
     inline size_t readable() const {
-        return (_write - _read) % Size;
+        return entries();
     }
 
     inline void write(T value) {
@@ -48,6 +53,6 @@ public:
 
 private:
     T _buffer[Size];
-    volatile size_t _read = 0;
-    volatile size_t _write = 0;
+    volatile int32_t _read = 0;
+    volatile int32_t _write = 0;
 };


### PR DESCRIPTION
I saw strange behaviour on the RingBuffer implementation due to the usage of size_t. If _read > _write you end up with negative numbers on modulo. Here my test case:

    size_t a = 4, b = 0, size = 6;
    size_t c = (b - a) % size;
    printf("c=%d", c);
-> output: c=0

    int32_t a = 4, b = 0, size = 6;
    int32_t c = (b - a) % size;
    if(c < 0) c+= size;
    printf("c=%d", c);
-> output: c=2