### PR TITLE
Reset on sequence start

### DIFF
--- a/src/apps/sequencer/Config.h
+++ b/src/apps/sequencer/Config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION_NAME             "PER|FORMER SEQUENCER"
 #define CONFIG_VERSION_MAJOR            0
 #define CONFIG_VERSION_MINOR            1
-#define CONFIG_VERSION_REVISION         36
+#define CONFIG_VERSION_REVISION         37
 
 // Task priorities
 #define CONFIG_DRIVER_TASK_PRIORITY     5

--- a/src/apps/sequencer/engine/Clock.cpp
+++ b/src/apps/sequencer/engine/Clock.cpp
@@ -275,6 +275,12 @@ void Clock::outputConfigureSwing(int swing) {
     _output.swing = swing;
 }
 
+void Clock::outputResetOnStart(bool resetOnStart) {
+    os::InterruptLock lock;
+    _resetOnStart = resetOnStart;
+    outputReset(!resetOnStart);
+}
+
 #define CHECK(_event_)                  \
     if (_requestedEvents & _event_) {   \
         _requestedEvents &= ~_event_;   \
@@ -358,7 +364,9 @@ void Clock::requestStop() {
     requestEvent(Stop);
     outputMidiMessage(MidiMessage::Stop);
     outputRun(false);
-    outputReset(false);
+    if (!_resetOnStart) {
+        outputReset(false);
+    }
 }
 
 void Clock::requestContinue() {
@@ -372,7 +380,9 @@ void Clock::requestReset() {
     requestEvent(Reset);
     outputMidiMessage(MidiMessage::Stop);
     outputRun(false);
-    outputReset(true);
+    if (!_resetOnStart) {
+        outputReset(true);
+    }
     outputClock(false);
 }
 

--- a/src/apps/sequencer/engine/Clock.cpp
+++ b/src/apps/sequencer/engine/Clock.cpp
@@ -278,7 +278,9 @@ void Clock::outputConfigureSwing(int swing) {
 void Clock::outputResetOnStart(bool resetOnStart) {
     os::InterruptLock lock;
     _resetOnStart = resetOnStart;
-    outputReset(!resetOnStart);
+    if (!isRunning()) {
+        outputReset(!resetOnStart);
+    }
 }
 
 #define CHECK(_event_)                  \

--- a/src/apps/sequencer/engine/Clock.h
+++ b/src/apps/sequencer/engine/Clock.h
@@ -79,6 +79,9 @@ public:
     void outputConfigureSwing(int swing);
     const OutputState &outputState() const { return _outputState; }
 
+    // Reset output
+    void outputResetOnStart(bool resetOnStart);
+
     // Sequencer interface
     Event checkEvent();
     bool checkTick(uint32_t *tick);
@@ -142,6 +145,8 @@ private:
     };
     Output _output;
     OutputState _outputState;
+
+    bool _resetOnStart = false;
 
     uint32_t _requestedEvents = Reset;
     State _state = State::Idle;

--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -345,7 +345,7 @@ Engine::Stats Engine::stats() const {
 void Engine::onClockOutput(const Clock::OutputState &state) {
     _dio.clockOutput.set(state.clock);
     switch (_project.clockSetup().clockOutputMode()) {
-    case ClockSetup::ClockOutputMode::Reset:
+    case ClockSetup::ClockOutputMode::Reset: case ClockSetup::ClockOutputMode::ResetOnStart:
         _dio.resetOutput.set(state.reset);
         break;
     case ClockSetup::ClockOutputMode::Run:
@@ -825,6 +825,9 @@ void Engine::updateClockSetup() {
 
     // Update clock outputs
     onClockOutput(_clock.outputState());
+
+    // Set clock reset output behaviour
+    _clock.outputResetOnStart(clockSetup.clockOutputMode() == ClockSetup::ClockOutputMode::ResetOnStart);
 
     clockSetup.clearDirty();
 }

--- a/src/apps/sequencer/model/ClockSetup.h
+++ b/src/apps/sequencer/model/ClockSetup.h
@@ -55,25 +55,27 @@ public:
 
     static const char *clockInputModeName(ClockInputMode mode) {
         switch (mode) {
-        case ClockInputMode::Reset:     return "Reset";
-        case ClockInputMode::Run:       return "Run";
-        case ClockInputMode::StartStop: return "Start/Stop";
-        case ClockInputMode::Last:      break;
+        case ClockInputMode::Reset:         return "Reset";
+        case ClockInputMode::Run:           return "Run";
+        case ClockInputMode::StartStop:     return "Start/Stop";
+        case ClockInputMode::Last:          break;
         }
         return nullptr;
     }
 
     enum class ClockOutputMode : uint8_t {
         Reset = 0,
+        ResetOnStart,
         Run,
         Last
     };
 
     static const char *clockOutputModeName(ClockOutputMode mode) {
         switch (mode) {
-        case ClockOutputMode::Reset:    return "Reset";
-        case ClockOutputMode::Run:      return "Run";
-        case ClockOutputMode::Last:     break;
+        case ClockOutputMode::Reset:        return "Reset";
+        case ClockOutputMode::ResetOnStart: return "Reset on start";
+        case ClockOutputMode::Run:          return "Run";
+        case ClockOutputMode::Last:         break;
         }
         return nullptr;
     }

--- a/src/apps/sequencer/python/project.cpp
+++ b/src/apps/sequencer/python/project.cpp
@@ -223,6 +223,7 @@ void register_project(py::module &m) {
 
     py::enum_<ClockSetup::ClockOutputMode>(clockSetup, "ClockOutputMode")
         .value("Reset", ClockSetup::ClockOutputMode::Reset)
+        .value("ResetOnStart", ClockSetup::ClockOutputMode::ResetOnStart)
         .value("Run", ClockSetup::ClockOutputMode::Run)
         .export_values()
     ;


### PR DESCRIPTION
Hi,

I recently ran into a problem when clocking my Malekko Voltage Block with my Performer.
It seems the Voltage Block expects a reset signal at the start of the sequence, rather than the default behaviour of the Performer which is to set reset high when the sequence is not running. This meant that the Voltage Block was always one step out of sync.

I've added a third output mode of "Reset on start" which fixes the problem.

Opened a PR since maybe this is useful for you/others. I'd appreciate any feedback - I've manually tested (not sure how you're approaching unit tests here), but let me know if there's anything else to add.

Great module and great work btw.