### PR TITLE
Toolchain Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup
-      run: make setup_stm32
+      run: |
+        make setup_stm32
+        echo "ARTIFACT_NAME=${GITHUB_REF_NAME}-$(git rev-parse --short HEAD)" | tr '/' '_' >> $GITHUB_ENV
     - name: Build
       run: (cd build/stm32/release && make -j)
     - name: Deploy
       run: make deploy
+    - name: Upload Artifact
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: build/deploy/**/*
     - name: Release
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
@@ -31,9 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Update
+      run: sudo apt update
     - name: Install Dependencies
       run: sudo apt install -y libsdl2-dev libasound2-dev mesa-common-dev python3 python3-dev
     - name: Setup
@@ -44,10 +54,10 @@ jobs:
       run: (cd build/sim/release && make test)
   sim_macos:
     name: Simulator Platform (macos)
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Install Dependencies
@@ -60,17 +70,17 @@ jobs:
       run: (cd build/sim/release && make test)
   sim_wasm:
     name: Simulation Platform (WebAssembly)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup emsdk
       run: |
         git clone https://github.com/emscripten-core/emsdk.git
-        ./emsdk/emsdk install latest
-        ./emsdk/emsdk activate latest
+        ./emsdk/emsdk install 3.1.74
+        ./emsdk/emsdk activate 3.1.74
     - name: Setup
       run: |
         source ./emsdk/emsdk_env.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/platform/stm32/libs/libopencm3"]
 	path = src/platform/stm32/libs/libopencm3
-	url = https://github.com/westlicht/libopencm3.git
+	url = https://github.com/libopencm3/libopencm3.git
 [submodule "src/platform/sim/libs/soloud"]
 	path = src/platform/sim/libs/soloud
 	url = https://github.com/jarikomppa/soloud.git

--- a/Makefile
+++ b/Makefile
@@ -50,15 +50,15 @@ tools_clean: arm_sdk_clean openocd_clean
 
 .PHONY: arm_sdk_install
 
-# Source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
-ARM_SDK_URL_BASE := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major
+# Source: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
+ARM_SDK_URL_BASE := https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1
 
 ifdef LINUX
-  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-$(ARCH)-linux.tar.bz2
+  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-$(ARCH)-arm-none-eabi.tar.xz
 endif
 
 ifdef MACOSX
-  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-mac.tar.bz2
+  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-darwin-$(ARCH)-arm-none-eabi.tar.xz
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
@@ -71,7 +71,7 @@ arm_sdk_install: arm_sdk_download $(ARM_SDK_INSTALL_MARKER)
 
 $(ARM_SDK_INSTALL_MARKER):
 	$(V1) mkdir -p $(ARM_SDK_DIR)
-	$(V1) tar -C $(ARM_SDK_DIR) --strip-components=1 -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) tar -C $(ARM_SDK_DIR) --strip-components=1 -xaf "$(DL_DIR)/$(ARM_SDK_FILE)"
 
 .PHONY: arm_sdk_download
 arm_sdk_download: | $(DL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ $(DL_DIR):
 
 # Determine host OS
 UNAME := $(shell uname)
+ARCH := $(shell uname -m)
 
 # Linux
 ifeq ($(UNAME), Linux)
@@ -50,10 +51,10 @@ tools_clean: arm_sdk_clean openocd_clean
 .PHONY: arm_sdk_install
 
 # Source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
-ARM_SDK_URL_BASE := https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update
+ARM_SDK_URL_BASE := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major
 
 ifdef LINUX
-  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-linux.tar.bz2
+  ARM_SDK_URL := $(ARM_SDK_URL_BASE)-$(ARCH)-linux.tar.bz2
 endif
 
 ifdef MACOSX

--- a/src/apps/bootloader/Bootloader.cpp
+++ b/src/apps/bootloader/Bootloader.cpp
@@ -240,7 +240,7 @@ static void bootloader() {
     }
 
     if (success && writeUpdate) {
-        printf("writing update image to 0x%08lx ...\n", CONFIG_APPLICATION_ADDR);
+        printf("writing update image to 0x%08ux ...\n", CONFIG_APPLICATION_ADDR);
 
         flash_unlock();
 

--- a/src/apps/bootloader/Lcd.cpp
+++ b/src/apps/bootloader/Lcd.cpp
@@ -74,7 +74,7 @@ void Lcd::init() {
 
     // init spi
     rcc_periph_clock_enable(RCC_SPI2);
-    spi_reset(LCD_SPI);
+    rcc_periph_reset_pulse(RST_SPI2);
     spi_init_master(LCD_SPI,
                     SPI_CR1_BAUDRATE_FPCLK_DIV_4,       // max LCD clock is 10MHz
                     SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE,

--- a/src/apps/bootloader/SdCard.cpp
+++ b/src/apps/bootloader/SdCard.cpp
@@ -85,7 +85,7 @@ void SdCard::powerOff() {
 }
 
 void SdCard::sendCommand(uint32_t cmd, uint32_t arg) {
-    cmd &= SDIO_CMD_CMDINDEX_MSK;
+    cmd &= SDIO_CMD_CMDINDEX_MASK;
     uint32_t waitresp = SDIO_CMD_WAITRESP_SHORT;
     if (cmd == 0) {
         waitresp = SDIO_CMD_WAITRESP_NO_0;

--- a/src/apps/bootloader/System.cpp
+++ b/src/apps/bootloader/System.cpp
@@ -9,7 +9,7 @@ uint32_t System::_ticks;
 
 void System::init() {
     // Base board frequency is 168MHz
-    rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+    rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
 
     // clock frequencies:
     // ahb_frequency  = 168000000

--- a/src/apps/sequencer/Sequencer.cpp
+++ b/src/apps/sequencer/Sequencer.cpp
@@ -124,7 +124,7 @@ static os::PeriodicTask<CONFIG_FILE_TASK_STACK_SIZE> fsTask("file", CONFIG_FILE_
 });
 
 #if CONFIG_ENABLE_PROFILER || CONFIG_ENABLE_TASK_PROFILER
-static CCMRAM_BSS os::PeriodicTask<CONFIG_PROFILER_TASK_STACK_SIZE> profilerTask("profiler", 0, os::time::ms(5000), [&] () {
+static CCMRAM_BSS os::PeriodicTask<CONFIG_PROFILER_TASK_STACK_SIZE> profilerTask("profiler", 0, os::time::ms(5000), [] () {
 #if CONFIG_ENABLE_PROFILER
     profiler.dump();
 #endif // CONFIG_ENABLE_PROFILE

--- a/src/platform/sim/sim/TargetTrace.cpp
+++ b/src/platform/sim/sim/TargetTrace.cpp
@@ -5,6 +5,7 @@
 #include "tinyformat.h"
 
 #include <iomanip>
+#include <memory>
 
 namespace sim {
 

--- a/src/platform/stm32/CMakeLists.txt
+++ b/src/platform/stm32/CMakeLists.txt
@@ -108,7 +108,9 @@ function(platform_postprocess_executable executable)
     add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${OBJCOPY} -Osrec ${executable} ${executable}.srec)
     add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${OBJDUMP} -dhS ${executable} > ${executable}.list)
     add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${SIZE} -A ${executable} > ${executable}.size)
-    add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${LINKER} -Map ${executable}.map ${executable} -o ${executable}.tmp && rm ${executable}.tmp)
+    # TODO: Generate a map file when initially linking the exe.
+    # Newer linker complains about using an executable as input, so this is disabled
+    #    add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${LINKER} -Map ${executable}.map ${executable} -o ${executable}.tmp && rm ${executable}.tmp)
     add_custom_command(TARGET ${executable} POST_BUILD COMMAND ${SIZE} --format=berkeley ${executable})
     add_openocd_targets(${executable})
 endfunction(platform_postprocess_executable)

--- a/src/platform/stm32/drivers/Lcd.cpp
+++ b/src/platform/stm32/drivers/Lcd.cpp
@@ -86,7 +86,7 @@ void Lcd::init() {
 
     // init spi
     rcc_periph_clock_enable(RCC_SPI2);
-    spi_reset(LCD_SPI);
+    rcc_periph_reset_pulse(RST_SPI2);
     spi_init_master(LCD_SPI,
                     SPI_CR1_BAUDRATE_FPCLK_DIV_2,       // max LCD clock is 10MHz
                     SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE,

--- a/src/platform/stm32/drivers/SdCard.cpp
+++ b/src/platform/stm32/drivers/SdCard.cpp
@@ -95,7 +95,7 @@ void SdCard::powerOff() {
 }
 
 void SdCard::sendCommand(uint32_t cmd, uint32_t arg) {
-    cmd &= SDIO_CMD_CMDINDEX_MSK;
+    cmd &= SDIO_CMD_CMDINDEX_MASK;
     uint32_t waitresp = SDIO_CMD_WAITRESP_SHORT;
     if (cmd == 0) {
         waitresp = SDIO_CMD_WAITRESP_NO_0;

--- a/src/platform/stm32/drivers/ShiftRegister.cpp
+++ b/src/platform/stm32/drivers/ShiftRegister.cpp
@@ -43,7 +43,7 @@ void ShiftRegister::init() {
 
     // init spi
     rcc_periph_clock_enable(RCC_SPI1);
-    spi_reset(SR_SPI);
+    rcc_periph_reset_pulse(RST_SPI1);
     spi_init_master(SR_SPI, SPI_CR1_BAUDRATE_FPCLK_DIV_8, // 84MHz / 8 = 10.5MHz < 20MHz
                     SPI_CR1_CPOL_CLK_TO_0_WHEN_IDLE,
                     SPI_CR1_CPHA_CLK_TRANSITION_1,

--- a/src/platform/stm32/drivers/System.cpp
+++ b/src/platform/stm32/drivers/System.cpp
@@ -8,7 +8,7 @@ volatile uint32_t System::_ticks;
 
 void System::init() {
     // Base board frequency is 168MHz
-    rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+    rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
 
     // clock frequencies:
     // ahb_frequency  = 168000000

--- a/src/platform/stm32/drivers/UsbH.cpp
+++ b/src/platform/stm32/drivers/UsbH.cpp
@@ -15,8 +15,8 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/timer.h>
-#include <libopencm3/stm32/otg_hs.h>
-#include <libopencm3/stm32/otg_fs.h>
+#include <libopencm3/usb/dwc/otg_hs.h>
+#include <libopencm3/usb/dwc/otg_fs.h>
 
 #define USB_PWR_EN_PORT GPIOC
 #define USB_PWR_EN_PIN GPIO9

--- a/src/platform/stm32/libs/libusbhost/src/usbh_lld_stm32f4.c
+++ b/src/platform/stm32/libs/libusbhost/src/usbh_lld_stm32f4.c
@@ -26,8 +26,8 @@
 
 #include <string.h>
 #include <stdint.h>
-#include <libopencm3/stm32/otg_hs.h>
-#include <libopencm3/stm32/otg_fs.h>
+#include <libopencm3/usb/dwc/otg_hs.h>
+#include <libopencm3/usb/dwc/otg_fs.h>
 
 
 

--- a/src/platform/stm32/os/os.h
+++ b/src/platform/stm32/os/os.h
@@ -12,6 +12,7 @@ extern "C" {
 }
 
 #include <functional>
+#include <algorithm>
 
 #include <libopencm3/cm3/cortex.h>
 


### PR DESCRIPTION
(This firmware seems inactive, but I'm putting this here for posterity and visibility.)

In preparation for future hacking, I've managed to update the toolchain (gcc 14.2), core library ([libopencm3](https://github.com/libopencm3/libopencm3)), and GitHub Actions CI workflow.

I had to make a few fixes to please the compiler (missing includes, lib API changes) and I disabled the post-process build step that generates a ".map" file due to a linker error. There are still some linker warnings... hopefully they aren't serious! I haven't tested the Simulator platforms at all, but they build successfully. The 4.0 series of **[emsdk](https://github.com/emscripten-core/emsdk)** broke the WASM build, so I held that one back to 3.1.74.

The CI workflow will produce **an artifact file** with the hardware binaries for every run, making it easier to build and test if you don't have a local toolchain set up (e.g. on Windows).